### PR TITLE
Fix SemVer ordering of releases

### DIFF
--- a/Model/Repos.cs
+++ b/Model/Repos.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 
 namespace dotnetthanks
@@ -126,8 +126,8 @@ namespace dotnetthanks
             // Clean up bot contributors
             foreach (var rel in Releases)
             {
-                rel.Contributors.FindAll(c => c.Name.StartsWith("dotnet-maestro")).ForEach(p => rel.Contributions -= p.Count);
-                rel.Contributors.RemoveAll(c => c.Name.StartsWith("dotnet-maestro"));
+                rel.Contributors.FindAll(c => c.Name.StartsWith("dotnet-maestro", StringComparison.OrdinalIgnoreCase)).ForEach(p => rel.Contributions -= p.Count);
+                rel.Contributors.RemoveAll(c => c.Name.StartsWith("dotnet-maestro", StringComparison.OrdinalIgnoreCase));
             }
 
             

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -10,7 +10,7 @@
                 @if (Model.LoadTags)
                 {
                 
-                    var rl = Model.CurrentRepo.Releases.OrderByDescending(o => o.Id).ToList();
+                    var rl = Model.CurrentRepo.Releases.OrderByDescending(o => o.Tag, SemVer2Comparer.Instance).ToList();
 
                     @for (int i=0; i<rl.Count; i++)
                     {

--- a/SemVer2Comparer.cs
+++ b/SemVer2Comparer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace dotnetthanks
+{
+    public class SemVer2Comparer : IComparer<string>
+    {
+        public static SemVer2Comparer Instance => new SemVer2Comparer();
+
+        private SemVer2Comparer()
+        {
+        }
+
+        public int Compare(string x, string y)
+        {
+            // The strings start with a "v" that we need to trim, then parse the rest as a semantic version
+            if (!NuGet.Versioning.SemanticVersion.TryParse(x?.Substring(1), out var xVersion))
+            {
+                // If 'x' isn't a semantic version, consider it less ("older") than 'y'
+                return -1;
+            }
+            if (!NuGet.Versioning.SemanticVersion.TryParse(y?.Substring(1), out var yVersion))
+            {
+                // If 'y' isn't a semantic version, consider it less ("older") than 'x'
+                return 1;
+            }
+
+            return xVersion.CompareTo(yVersion);
+        }
+    }
+}

--- a/dotnetthanks.csproj
+++ b/dotnetthanks.csproj
@@ -11,4 +11,8 @@
     <AssemblyInformationalVersion>$(AssemblyVersion).*.*+123345</AssemblyInformationalVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I figured it might be nice to order the releases by SemVer instead of by a seemingly-random identifier.

I also fixed a tiny potential bug with bot detection in case the app runs in a non-US culture.

Here's the old release sorting (effectively random):

![image](https://user-images.githubusercontent.com/202643/99439179-b418e500-28c9-11eb-8788-b4e70ae95f2a.png)

And this is the new sorting (by version, stable):

![image](https://user-images.githubusercontent.com/202643/99439195-bbd88980-28c9-11eb-8a36-aadfbacdc6af.png)
